### PR TITLE
batch: No retrieving DR when writing to DMI

### DIFF
--- a/src/target/riscv/batch.c
+++ b/src/target/riscv/batch.c
@@ -122,6 +122,7 @@ void riscv_batch_add_dmi_write(struct riscv_batch *batch, unsigned address, uint
 	field->in_value  = (void *)(batch->data_in  + batch->used_scans * DMI_SCAN_BUF_SIZE);
 	riscv_fill_dmi_write_u64(batch->target, (char *)field->out_value, address, data);
 	riscv_fill_dmi_nop_u64(batch->target, (char *)field->in_value);
+	field->in_value = NULL;
 	batch->last_scan = RISCV_SCAN_TYPE_WRITE;
 	batch->used_scans++;
 }


### PR DESCRIPTION
Indicate to the JTAG driver developer that he does not need to read and return the DR register value after scanning the JTAG chain.

riscv_batch_run(), calls jtag_add_dr_scan() to schedule a DR scan operation.  Eventually, this will result in the JTAG driver performing a JTAG scan to write to or read from the DR. The decision on whether to write to and/or read from the JTAG register is determined by the second parameter to jtag_add_dr_scan(), i.e.  a "struct scan_field". Of particular interest here is if batch->fields[i]->in_value is not NULL, the JTAG developer must return the DR value collected from the JTAG DR scan operation.

When creating the DR scan operation instruction with riscv_batch_add_dmi_write(), batch->fields[i]->in_value is pointed to a location in batch->data_in buffer, meaning batch->field[i]->in_value is not NULL, and the JTAG developer must read and return the DR value collected. The returning on the DR value is redundant in a write operation.

Normally, the extra work to return the DR value is negligible. However, in some use case it introduces delays that can be significant. Take the example of a JTAG driver that forwards all JTAG scan  to a server on a network. If the server has to return the DR value, it has to perform the JTAG scan before replying to the JTAG driver, and only then the JTAG driver can send the next request. However, if there is no need to return the DR value, the server can just acknowledge the JTAG operation and the JTAG driver is free to send the next JTAG scan operation. Parallelly, it will service the original JTAG scan request. This saves time and mitigate network delay. Also, not having to include the DR value in the reply packet from server to JTAG driver save on network traffic.

I could had deleted "riscv_fill_dmi_nop_u64(batch->target, (char *)field->in_value);"  right before the new code introduced in the patch. I didn't because I am not full clear about the consequence of doing so, even though I am expecting to be benign. I don't find it to have much impact to the overall speed of the JTAG driver yet, so I decided to keep it.

 in jtag_add_dr_scan() is sololy based on the second parameter.  perform write to and read from JTAG is decided by the second parameter, and in the our case, batch->fields[i]. if field[i]->in_value is not NULL, JTAG developer has to pass the DR register value in there.

For JTAG developer,
JTAG developer will read the and return the DR register value after scanning if jtag_dr_can